### PR TITLE
Custom wrangler.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,10 @@ Your Managed Component should be bundled before trying to deploy it.
 
 `npx managed-component-to-cloudflare-worker /path/to/managed/component.js component-name`
 
+### Custom wrangler.toml Configuration Using `npx`
+Pass the path to your custom wrangler.toml file as an optional third argument. Passed in component name will override the name in the custom wrangler.toml file.
+`npx managed-component-to-cloudflare-worker /path/to/managed/component.js component-name /path/to/wrangler.toml`
+
 ### Advanced: Manual Worker setup
 
 This method gives you more flexibility but requires you to be familiar with `wrangler` and Cloudflare Workers in general.

--- a/README.md
+++ b/README.md
@@ -12,8 +12,9 @@ Your Managed Component should be bundled before trying to deploy it.
 
 `npx managed-component-to-cloudflare-worker /path/to/managed/component.js component-name`
 
-### Custom wrangler.toml Configuration Using `npx`
-Pass the path to your custom wrangler.toml file as an optional third argument. Passed in component name will override the name in the custom wrangler.toml file.
+### Advanced: Custom wrangler.toml Configuration Using `npx`
+Pass the path to your custom wrangler.toml file as an optional third argument. Passed in component name will override the name in the custom wrangler.toml file. Assumes that a KV binding is configured in the custom wrangler.toml file bound to `KV` if required by the component.
+
 `npx managed-component-to-cloudflare-worker /path/to/managed/component.js component-name /path/to/wrangler.toml`
 
 ### Advanced: Manual Worker setup

--- a/bin/managed-component-to-cloudflare-worker.js
+++ b/bin/managed-component-to-cloudflare-worker.js
@@ -201,14 +201,16 @@ async function setupKVBinding() {
 
 Publish a custom Managed Component as a Cloudflare Worker, for using with Cloudflare Zaraz.
 
-Usage: npx managed-component-to-cloudflare-worker COMPONENT_SCRIPT WORKER_NAME
+Usage: npx managed-component-to-cloudflare-worker COMPONENT_SCRIPT WORKER_NAME [WRANGLER_TOML_PATH]
 
 COMPONENT_SCRIPT: Path to your compiled Managed Component JavaScript file
-WORKER_NAME: Name of the Cloudflare Worker to be created `)
+WORKER_NAME: Name of the Cloudflare Worker to be created
+WRANGLER_TOML_PATH: (Optional) Path to your custom wrangler.toml file`)
     exit(1)
   }
   const componentPath = process.argv[2]
   let workerName = process.argv[3]
+  let customWranglerTomlPath = process.argv[4]
 
   require('ts-node').register({
     files: true,
@@ -245,6 +247,13 @@ WORKER_NAME: Name of the Cloudflare Worker to be created `)
 
   // copy component code to the temporary folder
   fs.copyFileSync(componentPath, TMP_DIR + '/src/component.js')
+
+  // copy custom wrangler.toml if provided
+  if (customWranglerTomlPath) {
+    process.stdout.write('Copying your custom wrangler.toml...')
+    fs.copyFileSync(customWranglerTomlPath, WRANGLER_TOML_PATH)
+    console.log(' ✅')
+  }
 
   if (!workerName.startsWith('custom-mc-')) {
     workerName = 'custom-mc-' + workerName


### PR DESCRIPTION
## Overview
Adds support for a third parameter to pass in the path to a custom wrangler.toml.

## Behavior: 
When a custom wrangler.toml is used...
- The default template toml is ignored
- The second name parameter is still used, overriding anything in the custom toml
- The checks for adding a KV binding are ignored, since this is an advanced method and users are expected to have configured their own bindings (the primary use case for needing a custom toml)

When a custom wrangler.toml is *not* used..
- Same behavior as before, no change

## Issue
Closes #13 