### PR TITLE
attach env vars to the settings object

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,15 @@ This method gives you more flexibility but requires you to be familiar with `wra
   you have to add a KV binding. There are two ways to do this:
 
 1. Run `npx wrangler kv:namespace create <KV_NAMESPACE>`, copy the `id` string, and add binding in [wrangler.toml](wrangler.toml) as follows:
-   `kv_namespaces = [
-  { binding = "KV", id = "<YOUR_KV_ID>" }
-]`
+   ```
+   kv_namespaces = [
+     { binding = "KV", id = "<YOUR_KV_ID>" }
+   ]
+   ```
 2. After publishing this Managed Component as worker, follow [these steps](https://developers.cloudflare.com/workers/configuration/environment-variables/#add-environment-variables-via-the-dashboard) to add a KV binding as environment variable with variable name `KV`
 
 - Run `npx wrangler publish`
+
+#### Environment Variables
+
+To use worker environment variables/secrets in your managed component, add variables [via wrangler](https://developers.cloudflare.com/workers/configuration/environment-variables/#add-environment-variables-via-wrangler) or [via dashboard](https://developers.cloudflare.com/workers/configuration/environment-variables/#add-environment-variables-via-the-dashboard) and use them in your component through the `manager` parameter: `manager.env.YOUR_ENV_VARIABLE`

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^3.16.0",
-        "@managed-components/types": "^1.3.7",
+        "@managed-components/types": "^1.3.8",
         "@types/node": "^18.8.3",
         "ts-loader": "^9.4.1",
         "typescript": "^4.8.4"
@@ -135,9 +135,9 @@
       }
     },
     "node_modules/@managed-components/types": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/@managed-components/types/-/types-1.3.7.tgz",
-      "integrity": "sha512-VyRJFSaA7rrWHfAq94saKcJOKXEzln6V14Lkb8/D7mkwk8C1w1Sf9pRbZKnSS7KEUZl6TstCYZXDBUw6hNorMA==",
+      "version": "1.3.12",
+      "resolved": "https://registry.npmjs.org/@managed-components/types/-/types-1.3.12.tgz",
+      "integrity": "sha512-DivDuCBkzLJwEuAA6sPLAPR2nLQtuCNcIFP3CIs/N3IN/6swlKjtbXIfka6B4WgQq2OB6anDbXbg15v7YCEqQQ==",
       "dev": true
     },
     "node_modules/@miniflare/cache": {

--- a/src/component.js
+++ b/src/component.js
@@ -1,10 +1,10 @@
 async function c(n, i) {
   i.ecommerce &&
-    n.addEventListener('ecommerce', (e) => {
+    n.addEventListener('ecommerce', e => {
       e.name === 'Order Completed' &&
         console.info('Ka-ching! \u{1F4B0}', JSON.stringify(e.payload))
     }),
-    n.createEventListener('mousemove', async (e) => {
+    n.createEventListener('mousemove', async e => {
       let { payload: t } = e
       e.client.execute("console.log('\u{1F401} \u{1FAA4} Mousemove:')"),
         console.info(
@@ -12,7 +12,7 @@ async function c(n, i) {
           JSON.stringify(t, null, 2)
         )
     }),
-    n.createEventListener('mousedown', async (e) => {
+    n.createEventListener('mousedown', async e => {
       let { client: t, payload: o } = e
       e.client.execute(
         "console.log('\u{1F401} \u2B07\uFE0F Mousedown payload:')"
@@ -21,7 +21,7 @@ async function c(n, i) {
       let [s] = o.mousedown
       t.set('lastClickX', s.clientX), t.set('lastClickY', s.clientY)
     }),
-    n.createEventListener('historyChange', async (e) => {
+    n.createEventListener('historyChange', async e => {
       e.client.execute(
         "console.log('\u{1F4E3} Ch Ch Ch Chaaanges to history detected!')"
       ),
@@ -30,14 +30,14 @@ async function c(n, i) {
           e.payload
         )
     }),
-    n.createEventListener('resize', async (e) => {
+    n.createEventListener('resize', async e => {
       e.client.execute("console.log('\u{1FA9F} New window size!')"),
         console.info(
           '\u{1FA9F} New window size!',
           JSON.stringify(e.payload, null, 2)
         )
     }),
-    n.createEventListener('scroll', async (e) => {
+    n.createEventListener('scroll', async e => {
       e.client.execute(
         "console.log('\u{1F6DE}\u{1F6DE}\u{1F6DE} They see me scrollin...they hatin...')"
       ),
@@ -59,7 +59,7 @@ async function c(n, i) {
         e.attachEvent('historyChange'),
         e.attachEvent('scroll')
     }),
-    n.addEventListener('event', async (e) => {
+    n.addEventListener('event', async e => {
       let { client: t, name: o } = e
       o === 'verifiedSignup' &&
         (console.info(
@@ -69,7 +69,7 @@ async function c(n, i) {
           'console.log("\u{1F9C0}\u{1F9C0}  verifiedSignup event! \u{1F9C0}\u{1F9C0}")'
         ))
     }),
-    n.addEventListener('pageview', async (e) => {
+    n.addEventListener('pageview', async e => {
       let { client: t } = e
       console.info(
         '\u{1F4C4} Pageview received!',

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -22,7 +22,7 @@ export class Manager implements MCManager {
   #debug: boolean
   #response: Context['response']
   #execContext: ExecutionContext
-  #env: Env
+  env: Env
   name: string
 
   constructor(context: Context) {
@@ -36,7 +36,7 @@ export class Manager implements MCManager {
     this.#debug = context.debug
     this.#response = context.response
     this.#execContext = context.execContext
-    this.#env = context.env
+    this.env = context.env
     this.name = 'Zaraz'
   }
 
@@ -50,11 +50,11 @@ export class Manager implements MCManager {
     return true
   }
   async get(key: string) {
-    return await get(this.#env.KV, this.component + '__' + key)
+    return await get(this.env.KV, this.component + '__' + key)
   }
   set(key: string, value: any) {
     return set(
-      this.#env.KV,
+      this.env.KV,
       this.#execContext,
       this.component + '__' + key,
       value
@@ -109,7 +109,7 @@ export class Manager implements MCManager {
 
   async useCache(key: string, callback: Function, expiry?: number) {
     return await useCache(
-      this.#env.KV,
+      this.env.KV,
       this.#execContext,
       this.component + '__' + key,
       callback,
@@ -119,7 +119,7 @@ export class Manager implements MCManager {
 
   invalidateCache(key: string) {
     return invalidateCache(
-      this.#env.KV,
+      this.env.KV,
       this.#execContext,
       this.component + '__' + key
     )


### PR DESCRIPTION
This PR attaches the `env` object to the `settings` argument in the component callback function.

Users can then add worker environment variables or secrets and use them in their managed component workers.

Tested this by logging the "manager" argument inside `component.js`:

<img width="287" alt="Screenshot 2024-02-22 at 2 51 50 PM" src="https://github.com/cloudflare/managed-component-to-cloudflare-worker/assets/8991960/e755c97b-dd92-4110-b924-fca5645f537a">
<img width="346" alt="Screenshot 2024-02-22 at 2 51 55 PM" src="https://github.com/cloudflare/managed-component-to-cloudflare-worker/assets/8991960/050d8db2-0029-408d-9b83-e56856ceb71d">
<img width="322" alt="Screenshot 2024-02-22 at 2 52 14 PM" src="https://github.com/cloudflare/managed-component-to-cloudflare-worker/assets/8991960/f7c54f18-ad19-4646-b382-1aac2cc437fc">

